### PR TITLE
Filter AO stats by region

### DIFF
--- a/src/app/pages/ao/ao.page.html
+++ b/src/app/pages/ao/ao.page.html
@@ -5,7 +5,7 @@
       <ion-back-button></ion-back-button>
       <app-sidebar-toggle class="custom-back"></app-sidebar-toggle>
     </ion-buttons>
-    <ion-title>{{ displayName || 'Loading...' }}</ion-title>
+    <ion-title>{{ scopeDisplayName || 'Loading...' }}</ion-title>
     <ion-buttons slot="end">
       <ion-button [routerLink]="kotterRoute">Kotter</ion-button>
     </ion-buttons>
@@ -18,6 +18,24 @@
     (rangeChange)="onDateRangeChange($event)">
   </app-date-range-picker>
 
+  <ion-card *ngIf="all" class="region-filter-card">
+    <ion-card-content>
+      <ion-item lines="none">
+        <ion-label>Region</ion-label>
+        <ion-select
+          [(ngModel)]="selectedRegion"
+          interface="popover"
+          (ionChange)="onRegionFilterChange()">
+          <ion-select-option
+            *ngFor="let option of regionFilterOptions"
+            [value]="option.value">
+            {{ option.label }}
+          </ion-select-option>
+        </ion-select>
+      </ion-item>
+    </ion-card-content>
+  </ion-card>
+
   <div *ngIf="aoStats; else loading">
     <ng-container *ngIf="aoStats.totalBeatdowns > 0; else empty">
       <!-- ao stats -->
@@ -25,7 +43,7 @@
         <div class="card-container">
           <ion-card>
             <ion-card-header>
-              <ion-card-title>{{ displayName }} stats</ion-card-title>
+              <ion-card-title>{{ scopeDisplayName }} stats</ion-card-title>
               <ion-card-subtitle>
                 {{ aoStats.totalBeatdowns }} {{ aoStats.totalBeatdowns === 1 ? bbSingular : 'total ' + bbPlural }},
                 {{ aoStats.totalUniquePax }} total unique pax,
@@ -295,7 +313,7 @@
 <!-- empty state -->
 <ng-template #empty>
   <div class="empty-container">
-    No data for AO "{{ displayName }}"
+    No data for "{{ scopeDisplayName }}"
   </div>
 </ng-template>
 

--- a/src/app/pages/ao/ao.page.scss
+++ b/src/app/pages/ao/ao.page.scss
@@ -1,3 +1,12 @@
+.region-filter-card {
+  max-width: 1800px;
+  margin: 8px auto;
+
+  ion-card-content {
+    padding: 0;
+  }
+}
+
 .snapshot-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);

--- a/src/app/pages/ao/ao.page.ts
+++ b/src/app/pages/ao/ao.page.ts
@@ -11,7 +11,7 @@ import {PaxService} from 'src/app/services/pax.service';
 import {UtilService} from 'src/app/services/util.service';
 import {AoPaxStats, Backblast, BBType} from 'types';
 
-import {REGION_AGNOSTIC_AOS} from '../../../../constants';
+import {CANYON_AOS, CITY_OF_TREES_AOS, HIGH_DESERT_AOS, REGION_AGNOSTIC_AOS, SETTLERS_AOS} from '../../../../constants';
 
 interface AoStats {
   totalUniqueQs: number;      // count of unique qs
@@ -19,6 +19,12 @@ interface AoStats {
   totalBeatdowns: number;     // count of total beatdowns at this AO
   totalPosts: number;         // total of all beatdowns * participants
   averageAttendance: number;  // total posts / total beatdowns
+}
+
+interface RegionFilterOption {
+  label: string;
+  value: string;
+  aos?: Set<string>;
 }
 
 const LIMIT = 10;
@@ -84,6 +90,14 @@ export class AoPage {
   bbSingular = '';
   bbPlural = '';
   isRegion = false;
+  selectedRegion = 'all';
+  readonly regionFilterOptions: RegionFilterOption[] = [
+    {label: 'All', value: 'all'},
+    {label: 'Canyon', value: 'canyon', aos: CANYON_AOS},
+    {label: 'City of Trees', value: 'city-of-trees', aos: CITY_OF_TREES_AOS},
+    {label: 'High Desert', value: 'high-desert', aos: HIGH_DESERT_AOS},
+    {label: 'Settlers', value: 'settlers', aos: SETTLERS_AOS},
+  ];
 
   constructor(
       public readonly utilService: UtilService,
@@ -105,6 +119,15 @@ export class AoPage {
 
   get kotterRoute(): string {
     return this.isRegion ? `/region/${this.name}/kotter` : `/ao/${this.name}/kotter`;
+  }
+
+  get scopeDisplayName(): string {
+    if (!this.all || this.selectedRegion === 'all') {
+      return this.displayName;
+    }
+
+    return this.regionFilterOptions.find(option => option.value === this.selectedRegion)
+        ?.label ?? this.displayName;
   }
 
   private updateBBProperties() {
@@ -155,6 +178,11 @@ export class AoPage {
     this.calculateStats(range);
   }
 
+  onRegionFilterChange() {
+    this.reset();
+    this.calculateStats(this.selectedRange);
+  }
+
   goToPaxPage(name: string) {
     localStorage.setItem('BBTYPE', this.bbType);
     this.router.navigateByUrl(`/pax/${name}`);
@@ -168,9 +196,10 @@ export class AoPage {
       this.reset();
     }
 
-    const allData = this.all ?
+    const allDataForScope = this.all ?
         await this.backblastService.getAllData(this.bbType) :
         await this.backblastService.getBackblastsForAo(this.name, this.bbType);
+    const allData = this.filterBySelectedRegion(allDataForScope);
 
     // sort the data by date ascending
     const data: Backblast[] = [];
@@ -517,6 +546,24 @@ export class AoPage {
     this.topQsViewByPercentage = false;
     this.bottomQsViewByPercentage = false;
     this.noQsViewByLastBd = false;
+  }
+
+  private filterBySelectedRegion(backblasts: Backblast[]): Backblast[] {
+    if (!this.all || this.selectedRegion === 'all') {
+      return backblasts;
+    }
+
+    const regionAos =
+        this.regionFilterOptions.find(option => option.value === this.selectedRegion)
+            ?.aos;
+    if (!regionAos) {
+      return backblasts;
+    }
+
+    return backblasts.filter(backblast => {
+      const ao = backblast.ao.toLowerCase();
+      return regionAos.has(ao) && !REGION_AGNOSTIC_AOS.has(ao);
+    });
   }
 
   toggleLeaderboardView() {


### PR DESCRIPTION
## Summary
- Adds a Region dropdown to `/ao/all` with `All`, `Canyon`, `City of Trees`, `High Desert`, and `Settlers`.
- Keeps `All` as the default behavior.
- Filters the existing AO stats view by selected region, including top-line stats, Q Depth, Day-of-Week Attendance, leaderboards, and recent backblasts.

## Test plan
- Verified locally at `/ao/all`.
- Confirmed selecting each region updates the displayed AO stats scope.
- Confirmed focused diagnostics are clean for the edited AO page files.

## Notes
- This reuses the existing region AO sets already used by the sidebar.
- No new routes or data sources were added.